### PR TITLE
fix: use full repo path for local actions

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Run PR checks
-        uses: ./.github/actions/pr-checks@main
+        uses: nuonco/.github/.github/actions/pr-checks@main
   update_status:
     name: Update PR status
     if: github.event_name == 'pull_request' && always()


### PR DESCRIPTION
Reusable workflows can't reference local actions without workarounds. The calling workflow in the consumer repo won't have the local code checked out.